### PR TITLE
Remove auditions sections from website

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import PageHeader, { SiteBlurb } from "@/components/PageHeader";
 import SpotlightCard from "@/components/SpotlightCard";
-import AuditionCallout from "@/components/AuditionCallout";
 import AmbientBackground from "@/components/AmbientBackground";
 
 export const revalidate = 3600;
@@ -91,25 +90,7 @@ export default function Home() {
         </div>
       </section>
 
-      {/* Subtle divider */}
-      <div className="divider-theatrical my-8"></div>
-
-      {/* Audition Announcement Section */}
-      <section className="py-12 bg-black-warm">
-        <div className="container mx-auto px-4">
-          <motion.div
-            initial={{ opacity: 0, y: 30 }}
-            whileInView={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.7 }}
-            viewport={{ once: true }}
-          >
-            <AuditionCallout />
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Subtle divider */}
-      <div className="divider-theatrical my-8"></div>
+    
 
       {/* Mission Section */}
       <section className="py-12 bg-black-warm relative">

--- a/src/app/productions/sanctuary-city/page.tsx
+++ b/src/app/productions/sanctuary-city/page.tsx
@@ -10,7 +10,6 @@ import ShowContentSection from "@/components/show/ShowContentSection";
 import ShowSidebar from "@/components/show/ShowSidebar";
 import SocialShare from "@/components/show/SocialShare";
 import SpotlightCard from "@/components/SpotlightCard";
-import AuditionCallout from "@/components/AuditionCallout";
 
 export const revalidate = 3600;
 
@@ -101,10 +100,14 @@ export default function SanctuaryCityPage() {
             <motion.div
               initial={{ opacity: 0, y: 30 }}
               whileInView={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.7, delay: 0.2 }}
+              transition={{ duration: 0.7, delay: 0.4 }}
               viewport={{ once: true }}
             >
-              <AuditionCallout />
+              <div className="bg-black-deep/30 backdrop-blur-sm rounded-lg p-6 shadow-elevated">
+                <p className="text-2xl text-white text-center italic font-light tracking-wide leading-relaxed">
+                  Casting for <span className="text-accent font-normal">Sanctuary City</span> Coming Soon
+                </p>
+              </div>
             </motion.div>
           </div>
         </div>
@@ -129,7 +132,11 @@ export default function SanctuaryCityPage() {
                 transition={{ duration: 0.7, delay: 0.2 }}
                 viewport={{ once: true }}
               >
-                <AuditionCallout />
+                <div className="bg-black-deep/30 backdrop-blur-sm rounded-lg p-6 shadow-elevated">
+                  <p className="text-2xl text-white text-center italic font-light tracking-wide leading-relaxed">
+                    Casting for <span className="text-accent font-normal">Sanctuary City</span> Coming Soon
+                  </p>
+                </div>
               </motion.div>
             </div>
 


### PR DESCRIPTION
Auditions for Sanctuary City have finished. This update removes all audition callouts and replaces them with a "coming soon" message.

Changes:
- Homepage: Removed auditions section and surrounding dividers
- Sanctuary City page: Replaced audition callout with casting announcement
- Removed AuditionCallout component imports from both pages

The casting announcement uses blurb-style formatting and reads: "Casting for Sanctuary City Coming Soon"